### PR TITLE
WASM Buildpack Caching + Distroless

### DIFF
--- a/base-images/wasm/build/Dockerfile
+++ b/base-images/wasm/build/Dockerfile
@@ -4,14 +4,14 @@ FROM ${BASE_IMAGE} AS base
 # Install packages that we want to make available at build time
 USER root
 RUN apt update && \
-  apt install -y git wget jq && \
+  apt install -y git wget jq musl-tools && \
   rm -rf /var/lib/apt/lists/*
 
 USER heroku
 # Get Rust
 ENV CARGO_HOME=/home/heroku/.cargo
 ENV RUSTUP_HOME=/home/heroku/.rustup
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y -target=wasm32-wasip2
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --target=wasm32-wasip2,$(uname -m)-unknown-linux-musl
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 ENV PATH="$PATH:/home/heroku/.cargo/bin"
 

--- a/buildpacks/js/bin/build
+++ b/buildpacks/js/bin/build
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # TODO: Create layer.toml where the target directory is cached in build only. We will want to copy the .wasm artifacts into a layer or the workspace directory.
 
-wasm_component_layer="${CNB_LAYERS_DIR}"/wasm-js-components
+wasm_component_layer="${CNB_LAYERS_DIR}/wasm-js-components"
 mkdir -p "${wasm_component_layer}"
 cat > "${wasm_component_layer}.toml" << EOL
 [types]
@@ -12,6 +12,8 @@ launch = true
 cache = false
 build = false
 EOL
+
+echo "---> Copying .wasm files to layer"
 
 # recursively copy all files ending in .wasm into the layer directory and ignore the target and node_module directories
 find . -name "*.wasm" -not -path "./target/*" -not -path "./node_modules/*" -exec cp {} "${wasm_component_layer}" \;

--- a/buildpacks/wasm-tools/bin/build
+++ b/buildpacks/wasm-tools/bin/build
@@ -1,13 +1,35 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 wasm_tools_layer="${CNB_LAYERS_DIR}"/wasm-tools
-echo "---> Installing Wasm build tools into layer ${wasm_tools_layer}"
-mkdir -p "${wasm_tools_layer}/bin"
-CARGO_INSTALL_ROOT="${wasm_tools_layer}" cargo install --locked wasm-tools
-CARGO_INSTALL_ROOT="${wasm_tools_layer}" cargo install --locked wkg
+
+cargo_wasm_tools_version=$(cargo info -q wasm-tools | grep -m 1 'version:' | awk '{print $2}')
+metadata_wasm_tools_version=$(grep 'wasm_tools_version =' "${wasm_tools_layer}.toml" 2>/dev/null | awk -F ' = ' '{print $2}' | tr -d '"' || echo "")
+if [ "${cargo_wasm_tools_version}" != "${metadata_wasm_tools_version}" ]; then
+    echo "---> Installing Wasm build tools into layer ${wasm_tools_layer}"
+    mkdir -p "${wasm_tools_layer}/bin"
+    CARGO_INSTALL_ROOT="${wasm_tools_layer}" cargo install --locked wasm-tools
+else
+    echo "---> Reusing existing wasm-tools crate: ${metadata_wasm_tools_version}"
+fi
+
+cargo_wkg_version=$(cargo info -q wkg | grep -m 1 'version:' | awk '{print $2}')
+metadata_wkg_version=$(grep 'wkg_version =' "${wasm_tools_layer}.toml" 2>/dev/null | awk -F ' = ' '{print $2}' | tr -d '"' || echo "")
+
+if [ "${cargo_wkg_version}" != "${metadata_wkg_version}" ]; then
+    echo "---> Installing wkg crate into layer ${wasm_tools_layer}"
+    CARGO_INSTALL_ROOT="${wasm_tools_layer}" cargo install --locked wkg
+else
+    echo "---> Reusing existing wkg crate: ${metadata_wkg_version}"
+fi
 cat > "${wasm_tools_layer}.toml" << EOL
 [types]
 launch = false
 cache = true
 build = true
+
+[metadata]
+wasm_tools_version = "${cargo_wasm_tools_version}"
+wkg_version = "${cargo_wkg_version}"
 EOL

--- a/buildpacks/wasm-tools/bin/build
+++ b/buildpacks/wasm-tools/bin/build
@@ -9,7 +9,7 @@ metadata_wasm_tools_version=$(grep 'wasm_tools_version =' "${wasm_tools_layer}.t
 if [ "${cargo_wasm_tools_version}" != "${metadata_wasm_tools_version}" ]; then
     echo "---> Installing Wasm build tools into layer ${wasm_tools_layer}"
     mkdir -p "${wasm_tools_layer}/bin"
-    CARGO_INSTALL_ROOT="${wasm_tools_layer}" cargo install --locked wasm-tools
+    CARGO_INSTALL_ROOT="${wasm_tools_layer}" cargo install --locked --target $(uname -m)-unknown-linux-musl wasm-tools
 else
     echo "---> Reusing existing wasm-tools crate: ${metadata_wasm_tools_version}"
 fi
@@ -19,7 +19,7 @@ metadata_wkg_version=$(grep 'wkg_version =' "${wasm_tools_layer}.toml" 2>/dev/nu
 
 if [ "${cargo_wkg_version}" != "${metadata_wkg_version}" ]; then
     echo "---> Installing wkg crate into layer ${wasm_tools_layer}"
-    CARGO_INSTALL_ROOT="${wasm_tools_layer}" cargo install --locked wkg
+    CARGO_INSTALL_ROOT="${wasm_tools_layer}" cargo install --locked --target $(uname -m)-unknown-linux-musl wkg
 else
     echo "---> Reusing existing wkg crate: ${metadata_wkg_version}"
 fi

--- a/buildpacks/wasm-tools/bin/build
+++ b/buildpacks/wasm-tools/bin/build
@@ -11,5 +11,3 @@ launch = false
 cache = true
 build = true
 EOL
-
-export PATH="${PATH}:${wasm_tools_layer}/bin"

--- a/buildpacks/wasmtime-engine/bin/build
+++ b/buildpacks/wasmtime-engine/bin/build
@@ -14,5 +14,3 @@ launch = true
 cache = true
 build = true
 EOL
-
-export PATH="${PATH}:${wasmtime_engine_layer}/bin"

--- a/buildpacks/wasmtime-engine/bin/build
+++ b/buildpacks/wasmtime-engine/bin/build
@@ -13,6 +13,7 @@ CARGO_INSTALL_ROOT="${wasmtime_engine_layer}" cargo install \
   --profile='fastest-runtime' \
   --config='profile.fastest-runtime.strip="symbols"' \
   --config='profile.fastest-runtime.panic="abort"' \
+  --target="$(uname -m)-unknown-linux-musl" \
   wasmtime-cli
 else
   echo "---> Reusing existing wasmtime crate: ${metadata_wasmtime_version}"

--- a/buildpacks/wasmtime-engine/bin/build
+++ b/buildpacks/wasmtime-engine/bin/build
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 wasmtime_engine_layer="${CNB_LAYERS_DIR}"/wasmtime-engine
-echo "---> Installing Wasmtime into layer ${wasmtime_engine_tools_layer}"
+cargo_wasmtime_version=$(cargo info -q wasmtime-cli | grep -m 1 'version:' | awk '{print $2}')
+metadata_wasmtime_version=$(grep 'wasmtime_version =' "${wasmtime_engine_layer}.toml" 2>/dev/null | awk -F ' = ' '{print $2}' | tr -d '"' || echo "")
+
+if [ "${cargo_wasmtime_version}" != "${metadata_wasmtime_version}" ]; then
+  echo "---> Installing Wasmtime into layer ${wasmtime_engine_layer}"
 mkdir -p "${wasmtime_engine_layer}/bin"
 CARGO_INSTALL_ROOT="${wasmtime_engine_layer}" cargo install \
   --profile='fastest-runtime' \
   --config='profile.fastest-runtime.strip="symbols"' \
   --config='profile.fastest-runtime.panic="abort"' \
   wasmtime-cli
+else
+  echo "---> Reusing existing wasmtime crate: ${metadata_wasmtime_version}"
+fi
+
 cat > "${wasmtime_engine_layer}.toml" << EOL
 [types]
 launch = true
 cache = true
 build = true
+
+[metadata]
+wasmtime_version = "${cargo_wasmtime_version}"
 EOL


### PR DESCRIPTION
This PR makes two changes:
* Adds caching based off of the crate version to the wasmtime-engine + wasm-tools buildpacks which should be non-first build experiences much better.
* Uses a MUSL target so the binaries can run on the distroless static run image