### PR TITLE
add -S cli to the wasmtime entrypoint

### DIFF
--- a/buildpacks/js/bin/build
+++ b/buildpacks/js/bin/build
@@ -22,7 +22,7 @@ find . -name "*.wasm" -not -path "./target/*" -not -path "./node_modules/*" -exe
 cat > "${CNB_LAYERS_DIR}/launch.toml" << EOL
 [[processes]]
 type = "web"
-command = ["wasmtime", "serve", "${CNB_LAYERS_DIR}/wasm-js-components/server.component.wasm"]
+command = ["wasmtime", "serve", "-S", "cli", "${CNB_LAYERS_DIR}/wasm-js-components/server.component.wasm"]
 default = true
 EOL
 


### PR DESCRIPTION
Update the wasmtime entrypoint to include the `-S` flag for the CLI since the JS component imports wasi:cli interfaces. 