### PR TITLE
add a wac file to do composition using wac compose

### DIFF
--- a/apps/compose/Makefile
+++ b/apps/compose/Makefile
@@ -38,9 +38,7 @@ run: ## Run the microservice app after build.
 	wasmtime serve -S cli $(COMPOSED_COMPONENT_PATH)
 
 .PHONY: build-and-run
-build-and-run: build ## Build and run the microservice app.
-	$(info "Running Component Application Using Wasmtime...")
-	wasmtime serve -S cli $(COMPOSED_COMPONENT_PATH)
+build-and-run: build run ## Build and run the microservice app.
 
 ##@ Cleanup:
 

--- a/apps/compose/Makefile
+++ b/apps/compose/Makefile
@@ -29,15 +29,16 @@ build-go: ## Build the Go app.
 .PHONY: build-compose
 build-compose: ## Build the Docker Compose app.
 	$(info "Fusing components together with wac...")
-	@wac plug --plug $(GO_COMPONENT_PATH) -o composed.wasm $(SERVER_COMPONENT_PATH)
+	# @wac plug --plug $(GO_COMPONENT_PATH) -o composed.wasm $(SERVER_COMPONENT_PATH)
+	wac compose --dep example:math=$(GO_COMPONENT_PATH) --dep example:server=$(SERVER_COMPONENT_PATH) -o composed.wasm compose.wac
 
 .PHONY: run
-run: build ## Run the JavaScript app.
+run: ## Run the microservice app after build.
 	$(info "Running Component Application Using Wasmtime...")
 	wasmtime serve -S cli $(COMPOSED_COMPONENT_PATH)
 
 .PHONY: build-and-run
-build-and-run: build ## Build and run the JavaScript app.
+build-and-run: build ## Build and run the microservice app.
 	$(info "Running Component Application Using Wasmtime...")
 	wasmtime serve -S cli $(COMPOSED_COMPONENT_PATH)
 

--- a/apps/compose/compose.wac
+++ b/apps/compose/compose.wac
@@ -1,0 +1,11 @@
+package example:microservice;
+
+// Instantiate the `math` component
+let math = new example:math {...};
+
+// Instantiate the `server` component by plugging its `adder`
+// import with the `adder` export of the `math` component.
+let server = new example:server {adder: math.adder, ...};
+
+// Export the hander function from the server component
+export server.incoming-handler;


### PR DESCRIPTION
This PR adds a `compose.wac` file which describes the composition of the `math` and `server` components using the `wac compose` command. This allows for more flexibility for user defined composition rather than using `wac plug`, which would require the builder to understand which components are the plug and which one is the socket.